### PR TITLE
Fixed projects overflow, Updated buttons to smaller dimensions

### DIFF
--- a/public/pages/scrollableSite.tsx
+++ b/public/pages/scrollableSite.tsx
@@ -30,11 +30,11 @@ export const ScrollableSite: React.FC= () => {
   
     return (
         <div className="select-none text-[#f1f5f9] tracking-wide">
-            <div className="fixed flex flex-col *:m-6 *:text-sm *:lg:text-2xl items-center justify-center w-1/4 lg:w-1/5 h-full lg:h-4/5 *:cursor-pointer lg:translate-y-[10%] lg:translate-x-1/4 bg-[#121212] rounded-lg backdrop-filter backdrop-blur-sm bg-opacity-80 border-2 border-black shadow-md"> {/*md:translate-y-20 md:translate-x-1/4*/}
+            <div className="fixed flex flex-col *:m-6 *:text-sm *:lg:text-2xl items-center justify-center w-1/4 lg:w-1/5 h-full lg:h-4/5 *:cursor-pointer lg:translate-y-[10%] lg:translate-x-1/4 bg-[#121212] lg:rounded-lg backdrop-filter backdrop-blur-sm bg-opacity-80 border-2 border-black shadow-md"> {/*md:translate-y-20 md:translate-x-1/4*/}
                 <div className="text-center align-middle">
                     <Link href="#Introduction"
                         className={`${
-                            activeSection === "Introduction" ? "text-slate-100 transform scale-125" : "text-slate-600"
+                            activeSection === "Introduction" ? "text-slate-100 transform scale-110" : "text-slate-600"
                         } hover:text-slate-100 transition-all duration-200 ease-in-out inline-block`}
                         >
                         Introduction
@@ -43,7 +43,7 @@ export const ScrollableSite: React.FC= () => {
                 <div className="text-center align-middle">
                     <Link href="#Education"
                         className={`${
-                            activeSection === "Education" ? "text-slate-100 transform scale-125" : "text-slate-600"
+                            activeSection === "Education" ? "text-slate-100 transform scale-110" : "text-slate-600"
                         } hover:text-slate-100 transition-all duration-200 ease-in-out inline-block`}
                         >
                         Education
@@ -52,7 +52,7 @@ export const ScrollableSite: React.FC= () => {
                 <div className="text-center align-middle">
                     <Link href="#Projects"
                         className={`${
-                            activeSection === "Projects" ? "text-slate-100 transform scale-125" : "text-slate-600"
+                            activeSection === "Projects" ? "text-slate-100 transform scale-110" : "text-slate-600"
                         } hover:text-slate-100 transition-all duration-200 ease-in-out inline-block`}
                         >
                         Projects
@@ -61,7 +61,7 @@ export const ScrollableSite: React.FC= () => {
                 <div className="text-center align-middle">
                     <Link href="#Experience"
                         className={`${
-                            activeSection === "Experience" ? "text-slate-100 transform scale-125" : "text-slate-600"
+                            activeSection === "Experience" ? "text-slate-100 transform scale-110" : "text-slate-600"
                         } hover:text-slate-100 transition-all duration-200 ease-in-out inline-block`}
                         >
                         Experience
@@ -70,7 +70,7 @@ export const ScrollableSite: React.FC= () => {
                 <div className="self-center text-center align-middle">
                     <Link href="#section5"
                         className={`${
-                            activeSection === "section5" ? "text-slate-100 transform scale-125" : "text-slate-600"
+                            activeSection === "section5" ? "text-slate-100 transform scale-110" : "text-slate-600"
                         } hover:text-slate-100 transition-all duration-200 ease-in-out inline-block`}
                         >
                         Section 5
@@ -101,30 +101,25 @@ export const ScrollableSite: React.FC= () => {
                                     <br></br><br></br>
                                     <br></br><br></br>
                                 </div>
-                                <div className="flex flex-row flex-wrap *:mr-4 *:mb-4 *:size-14 *:bg-[#100000] *:rounded-2xl *:cursor-pointer">
-                                    {/* <div className="flex items-center justify-center hover:scale-110 group">
-                                        <div className="text-4xl group-hover:scale-110 group-hover:inline-block group-hover:text-transparent group-hover:bg-gradient-to-r group-hover:from-blue-600 group-hover:via-amber-700 group-hover:to-indigo-40 group-hover:bg-clip-text">
-                                            X
-                                        </div>
-                                    </div>*/}
+                                <div className="flex flex-row flex-wrap *:mr-4 *:mb-4 *:lg:size-14 *:size-12 *:bg-[#100000] *:rounded-2xl *:cursor-pointer">
                                     <Link className="flex items-center justify-center hover:scale-110 group" href="mailto:JakinChan200@gmail.com" target="_blank" passHref={true}>
                                         <button className="">
-                                        <svg width="35" height="35" fill="none" viewBox="0 0 24 24">
-                                            <path stroke="#FFF" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m4 7 6.2 4.65a3 3 0 0 0 3.6 0L20 7"/>
-                                            <rect width="18" height="14" x="3" y="5" stroke="#FFF" stroke-linecap="round" stroke-width="2" rx="2"/>
-                                        </svg>   
+                                            <svg className="lg:size-8 size-7" fill="none" viewBox="0 0 24 24">
+                                                <path stroke="#FFF" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m4 7 6.2 4.65a3 3 0 0 0 3.6 0L20 7"/>
+                                                <rect width="18" height="14" x="3" y="5" stroke="#FFF" stroke-linecap="round" stroke-width="2" rx="2"/>
+                                            </svg>   
                                         </button>
                                     </Link>
                                     <Link className="flex items-center justify-center hover:scale-110 group" href="https://github.com/JakinChan200" target="_blank" passHref={true}>
                                         <button className="">
-                                            <svg width="35" height="35" viewBox="0 0 24 24" className="fill-white">
+                                            <svg className="fill-white size-7 lg:size-8" viewBox="0 0 24 24">
                                                 <path d="M4.074 2.994c.059-1.03.305-1.478 1.01-1.838.76-.387 1.957-.207 3.366.507.607.307.669.313 1.732.177 1.414-.181 3.234-.18 4.54.002.986.138 1.05.13 1.66-.177 2-1.013 3.578-.947 4.15.174.286.56.339 2.01.117 3.208-.122.664-.11.747.186 1.182 2.08 3.065.581 8.033-2.982 9.887a6.16 6.16 0 0 1-.69.3c-.575.22-.75.287-.538 1.298.102.486.224 1.695.272 2.686.087 1.792.086 1.805-.228 2.17-.428.498-1.045.506-1.462.02-.273-.317-.3-.466-.3-1.689 0-1.806-.197-3.006-.665-4.035-.557-1.224-.144-1.681 1.128-1.955 1.768-.38 3.15-1.471 3.92-3.096.731-1.545.841-3.68-.482-4.978-.376-.447-.402-.853-.134-2.074.1-.456.185-1.045.188-1.309.003-.416-.035-.479-.29-.479-.162 0-.78.236-1.373.523l-.947.459a.504.504 0 0 1-.277.047 30.339 30.339 0 0 0-7.114 0 .504.504 0 0 1-.279-.046l-.946-.46c-.593-.287-1.211-.523-1.373-.523-.374 0-.38.276-.039 1.916.209 1.001.349 1.224-.253 2.025-.902 1.2-1.127 2.69-.643 4.256.609 1.973 2.101 3.305 4.2 3.75 1.265.268 1.595.618 1.112 2.069-.38 1.14-.62 1.435-1.173 1.435-.743 0-1.209-.644-.953-1.318.113-.297.08-.329-.617-.582-2.126-.776-3.752-2.513-4.495-4.804-.575-1.77-.322-4.075.6-5.467.314-.475.318-.515.172-1.423a10.301 10.301 0 0 1-.1-1.838ZM3.332 15.945a1 1 0 0 0-1.664 1.11c.226.34.497.618.726.848l.124.123c.193.19.363.36.533.56.378.443.754 1.04.968 2.11.096.477.438.734.628.846.206.121.431.193.616.24.379.095.839.145 1.275.174.479.032.998.042 1.462.045a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1h-.304c-.587.002-1.352.004-2.026-.04a6.837 6.837 0 0 1-.788-.09c-.301-1.184-.788-1.972-1.308-2.582-.23-.27-.468-.506-.662-.698a30.47 30.47 0 0 1-.103-.103c-.224-.223-.37-.382-.477-.543Z"/>
                                             </svg>        
                                         </button>
                                     </Link>
                                     <Link className="flex items-center justify-center hover:scale-110 group" href="https://www.linkedin.com/in/jakin200/" target="_blank" passHref={true}>
                                         <button className="">
-                                            <svg width="25" height="25" viewBox="0 0 310 310" className="fill-white">
+                                            <svg className="fill-white size-6 lg:size-7" viewBox="0 0 310 310">
                                                 <path d="M72.16 99.73H9.927a5 5 0 0 0-5 5v199.928a5 5 0 0 0 5 5H72.16a5 5 0 0 0 5-5V104.73a5 5 0 0 0-5-5zM41.066.341C18.422.341 0 18.743 0 41.362 0 63.991 18.422 82.4 41.066 82.4c22.626 0 41.033-18.41 41.033-41.038C82.1 18.743 63.692.341 41.066.341zM230.454 94.761c-24.995 0-43.472 10.745-54.679 22.954V104.73a5 5 0 0 0-5-5h-59.599a5 5 0 0 0-5 5v199.928a5 5 0 0 0 5 5h62.097a5 5 0 0 0 5-5V205.74c0-33.333 9.054-46.319 32.29-46.319 25.306 0 27.317 20.818 27.317 48.034v97.204a5 5 0 0 0 5 5H305a5 5 0 0 0 5-5V194.995c0-49.565-9.451-100.234-79.546-100.234z"/>
                                             </svg>      
                                         </button>
@@ -158,11 +153,11 @@ export const ScrollableSite: React.FC= () => {
                     <section id="Projects" className={`${ activeSection === "Projects" ? "opacity-100" : "opacity-0 pointer-events-none" } `}>
                         <div className="flex flex-col items-center justify-center w-full h-screen">
                             <h2 className="my-8 text-2xl text-center lg:text-4xl">Projects</h2>
-                            <div className="justify-center w-3/4 h-3/5">
-                                <div className="overflow-x-scroll overflow-y-visible w-full h-3/4 gap-4 justify-start *:w-64 *:h-full flex snap-x *:bg-[#121212] *:rounded-md *:flex-shrink-0 *:snap-start">
-                                    <div className="w-full h-full">
+                            <div className="w-3/4 h-[530px]">
+                                <div className="overflow-x-scroll h-3/4 gap-4 justify-start *:w-64 *:h-full flex snap-x *:bg-[#121212] *:rounded-md *:flex-shrink-0 *:snap-start">
+                                    <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="flex items-center justify-center w-full h-12 mb-4 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-2xl">
                                                 2048
                                             </div>
                                             <div className="w-full mb-4 text-md">
@@ -172,16 +167,16 @@ export const ScrollableSite: React.FC= () => {
                                                 Tech Stack:
                                                 <p>-Python</p>
                                             </div>
-                                            <Link className="relative bottom-0" href="https://github.com/JakinChan200/2048" target="_blank" passHref={true}>
-                                                <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
-                                                    &rarr;
-                                                </button>
-                                            </Link>
                                         </div>
+                                        <Link className="absolute bottom-0 right-0 m-4" href="https://github.com/JakinChan200/2048" target="_blank" passHref={true}>
+                                            <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
+                                                &rarr;
+                                            </button>
+                                        </Link>
                                     </div>
-                                    <div className="h-full">
+                                    <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="flex items-center justify-center w-full h-12 mb-4 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-2xl">
                                                 Summarizer
                                             </div>
                                             <div className="w-full mb-4 text-md">
@@ -196,16 +191,16 @@ export const ScrollableSite: React.FC= () => {
                                                 <p>-Flask</p>
                                                 <p>-Python</p>
                                             </div>
-                                            <Link className="relative bottom-0" href="https://github.com/liz-areizaga/summarizer" target="_blank" passHref={true}>
-                                                <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
-                                                    &rarr;
-                                                </button>
-                                            </Link>
                                         </div>
+                                        <Link className="absolute bottom-0 right-0 m-4" href="https://github.com/liz-areizaga/summarizer" target="_blank" passHref={true}>
+                                            <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
+                                                &rarr;
+                                            </button>
+                                        </Link>
                                     </div>
-                                    <div className="h-full">
+                                    <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="flex items-center justify-center w-full h-12 mb-4 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-2xl">
                                                 Fault Finding
                                             </div>
                                             <div className="w-full mb-4 text-md">
@@ -216,16 +211,16 @@ export const ScrollableSite: React.FC= () => {
                                                 <p>-C++</p>
                                                 <p>-GCOV</p>
                                             </div>
-                                            <Link className="relative bottom-0" href="https://github.com/JakinChan200/CS206" target="_blank" passHref={true}>
-                                                <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
-                                                    &rarr;
-                                                </button>
-                                            </Link>
                                         </div>
+                                        <Link className="absolute bottom-0 right-0 m-4" href="https://github.com/JakinChan200/CS206" target="_blank" passHref={true}>
+                                            <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
+                                                &rarr;
+                                            </button>
+                                        </Link>
                                     </div>
-                                    <div className="h-full">
+                                    <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="flex items-center justify-center w-full h-12 mb-4 text-2xl">
+                                            <div className="text-center m-2 w-full h-12 text-2xl">
                                                 Feature Selection
                                             </div>
                                             <div className="w-full mb-4 text-md">
@@ -235,12 +230,12 @@ export const ScrollableSite: React.FC= () => {
                                                 Tech Stack:
                                                 <p>-C++</p>
                                             </div>
-                                            <Link className="relative bottom-0" href="https://github.com/JakinChan200/CS205Project2" target="_blank" passHref={true}>
-                                                <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
-                                                    &rarr;
-                                                </button>
-                                            </Link>
                                         </div>
+                                        <Link className="absolute bottom-0 right-0 m-4" href="https://github.com/JakinChan200/CS205Project2" target="_blank" passHref={true}>
+                                            <button className="px-3 py-1 font-semibold bg-blue-500 rounded-lg">
+                                                &rarr;
+                                            </button>
+                                        </Link>
                                     </div>
                                     <div className="">
                                         
@@ -249,7 +244,7 @@ export const ScrollableSite: React.FC= () => {
                                         
                                     </div>
                                 </div>
-                                <div className="flex flex-row w-full h-1/3">
+                                <div className="flex flex-row w-full h-1/4 mt-4">
                                     <div className="w-full">
                                         <div className="flex items-center justify-center pointer-events-none h-1/2">
                                             <a href="https://skillicons.dev">

--- a/public/pages/scrollableSite.tsx
+++ b/public/pages/scrollableSite.tsx
@@ -154,16 +154,16 @@ export const ScrollableSite: React.FC= () => {
                         <div className="flex flex-col items-center justify-center w-full h-screen">
                             <h2 className="my-8 text-2xl text-center lg:text-4xl">Projects</h2>
                             <div className="w-3/4 h-[530px]">
-                                <div className="overflow-x-scroll h-3/4 gap-4 justify-start *:w-64 *:h-full flex snap-x *:bg-[#121212] *:rounded-md *:flex-shrink-0 *:snap-start">
+                                <div className="overflow-x-scroll overflow-y-hidden h-3/4 gap-4 justify-start *:w-64 *:h-full flex snap-x *:bg-[#121212] *:rounded-md *:flex-shrink-0 *:snap-start">
                                     <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="text-center w-full m-2 h-12 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-xl lg:text-2xl">
                                                 2048
                                             </div>
-                                            <div className="w-full mb-4 text-md">
+                                            <div className="w-full mb-4 text-sm lg:text-base">
                                                 In a team, built a GUI to play the hit game 2048 or have a bot play for you.
                                             </div>
-                                            <div className="w-full text-md">
+                                            <div className="w-full text-sm lg:text-base">
                                                 Tech Stack:
                                                 <p>-Python</p>
                                             </div>
@@ -176,13 +176,13 @@ export const ScrollableSite: React.FC= () => {
                                     </div>
                                     <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="text-center w-full m-2 h-12 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-xl lg:text-2xl">
                                                 Summarizer
                                             </div>
-                                            <div className="w-full mb-4 text-md">
+                                            <div className="w-full mb-4 text-sm lg:text-base">
                                                 In a team, built a Chat-GPT wrapper to summarize content given a YouTube link or text. Dark mode included.
                                             </div>
-                                            <div className="w-full text-md">
+                                            <div className="w-full text-sm lg:text-base">
                                                 Tech Stack:
                                                 <p>-React</p>
                                                 <p>-Tailwind CSS</p>
@@ -200,13 +200,13 @@ export const ScrollableSite: React.FC= () => {
                                     </div>
                                     <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="text-center w-full m-2 h-12 text-2xl">
+                                            <div className="text-center w-full m-2 h-12 text-xl lg:text-2xl">
                                                 Fault Finding
                                             </div>
-                                            <div className="w-full mb-4 text-md">
+                                            <div className="w-full mb-4 text-sm lg:text-base">
                                                 In a team, given a piece of code, and a suite of test cases, minimize the number of test cases while maintaining full coverage.
                                             </div>
-                                            <div className="w-full text-md">
+                                            <div className="w-full text-sm lg:text-base">
                                                 Tech Stack:
                                                 <p>-C++</p>
                                                 <p>-GCOV</p>
@@ -220,13 +220,13 @@ export const ScrollableSite: React.FC= () => {
                                     </div>
                                     <div className="relative">
                                         <div className="flex flex-col items-center p-4">
-                                            <div className="text-center m-2 w-full h-12 text-2xl">
+                                            <div className="text-center m-2 w-full h-12 text-xl lg:text-2xl">
                                                 Feature Selection
                                             </div>
-                                            <div className="w-full mb-4 text-md">
+                                            <div className="w-full mb-4 text-sm lg:text-base">
                                                 Implemented leave-one-out feature selction to process and develop a classifier.
                                             </div>
-                                            <div className="w-full text-md">
+                                            <div className="w-full text-sm lg:text-base">
                                                 Tech Stack:
                                                 <p>-C++</p>
                                             </div>


### PR DESCRIPTION
## Overview
 * Updated Introduction buttons to adapt to smaller screen sizes
 * Reduced Projects y overflow
 * Reduced scale increase of the nav bar when on the section
 * Fixed overlap of Project cards and Project icons at smaller screen sizes
 * Fixed Project card links to be uniform

### To Do
 * Adapt project cards to smaller screen sizes

## Materials
- 


## Pictures
Before
![image](https://github.com/user-attachments/assets/7757a6dd-d6b2-447d-ace2-70bcbeb207f9)
After
![image](https://github.com/user-attachments/assets/3e77555c-c854-4d0b-8556-42cdae31bbb3)


## Manual Testing Guide
- Navigate to the `site` folder
- Run `npm i`
- Run `npm run dev`

Pull requests should receive approval before merge.